### PR TITLE
Implement batch mode

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func splitpath(path string) (string, string) {
+	path_components := strings.Split(path, "/")
+	basename := path_components[len(path_components)-1]
+	dirname := strings.Join(path_components[:len(path_components)-1], "/")
+	return basename, dirname
+}
+
+func is_hidden_file(path string) bool {
+	basename, _ := splitpath(path)
+	return strings.HasPrefix(basename, ".")
+}
+
+func aggregate_to_file(decks []*Deck, deckname string, output_path string) {
+	var archetypical_deck *Deck
+	if len(decks) == 1 {
+		// trivially, a single deck's aggregate is itself
+		archetypical_deck = decks[0]
+	} else {
+		var err error
+		archetypical_deck, err = aggregate(decks)
+		if err != nil {
+			log.Fatalln("Couldn't create archetype for", deckname+":", err)
+		}
+	}
+
+	err := os.MkdirAll(output_path, 0755)
+	if err != nil {
+		log.Fatalln("Couldn't create output directory", output_path+":", err)
+	}
+	filename := output_path + "/" + deckname + "-aggregate.txt"
+	err = ioutil.WriteFile(filename, []byte(archetypical_deck.String()), 0644)
+	if err != nil {
+		log.Fatalln("Couldn't write output file", output_path+":", err)
+	}
+}
+
+func strip_trailing_slash(s *string) {
+	l := len(*s)
+	if (*s)[l-1] == '/' {
+		*s = (*s)[:l-2]
+	}
+}
+
+func batch(top_path string, output_path string, verbose bool) {
+	decks_processed := 0
+	aggregate_decks_created := 0
+
+	strip_trailing_slash(&top_path)
+	strip_trailing_slash(&output_path)
+
+	var deck_dir, deckname string
+	decks := make([]*Deck, 0)
+
+	filepath.Walk(top_path, func(path string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		if is_hidden_file(path) {
+			if verbose {
+				log.Println("  Ignoring hidden file", path)
+			}
+			return nil
+		}
+
+		basename, dirname := splitpath(path)
+
+		// if we're traversing a new folder
+		if deck_dir != dirname {
+
+			// aggregate what we've got already from previous folder
+			if len(decks) > 0 {
+				deckname := strings.Replace(deck_dir[len(top_path)+1:], "/", "-", -1)
+
+				if verbose {
+					log.Println("  Aggregating previous", len(decks), "decks")
+				}
+				aggregate_to_file(decks, deckname, output_path)
+				aggregate_decks_created++
+			}
+
+			// allocate structures to collect decks from this new folder
+			decks = make([]*Deck, 0)
+			deck_dir = dirname
+			deckname = strings.Replace(deck_dir[len(top_path)+1:], "/", "-", -1)
+			if verbose {
+				log.Println("Scanning for decks in", dirname)
+			}
+		}
+
+		// we've found a deckfile
+		if verbose {
+			log.Println("  Parsing deck", basename)
+		}
+
+		// read the deckfile
+		deckfile, err := os.Open(path)
+		if err != nil {
+			log.Fatalln("Path open failed for deck", path+":", err)
+		}
+		deck, err := NewDeck(deckfile)
+		if err != nil {
+			log.Fatalln("Deck parsing failed for deck", path+":", err)
+		}
+
+		decks = append(decks, deck)
+		decks_processed++
+		return nil
+	})
+
+	if verbose {
+		log.Println("  Aggregating previous", len(decks), "decks")
+	}
+	aggregate_to_file(decks, deckname, output_path)
+	aggregate_decks_created++
+
+	log.Println(decks_processed, "decks processed from", top_path)
+	log.Println(aggregate_decks_created, "aggregate decks created in", output_path)
+}

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"strconv"
+)
+
+var batchmode = flag.Bool("batch", false, "Whether to run in batch mode (requires -decks and -out)")
+var deckpath = flag.String("decks", "", "(batch mode) A directory with subdirectories containing deck files")
+var outpath = flag.String("out", "", "(batch mode) Output directory for aggregated decks; will be created if it doesn't exist")
+var servermode = flag.Bool("web", false, "Whether to run in webserver mode")
+var port = flag.Int("port", 8981, "(web mode) Port to bind to")
+var prefix = flag.String("prefix", "metadeck", "(web mode) Route at which to serve the web interface")
+var verbose = flag.Bool("v", false, "Give more verbose output")
+
+func main() {
+	flag.Parse()
+	if *batchmode || (*deckpath != "" && *outpath != "") {
+		if *deckpath == "" || *outpath == "" {
+			log.Fatalln("Batch operation requires --decks and --out arguments. Consult --help for more information.")
+		}
+		batch(*deckpath, *outpath, *verbose)
+	} else {
+		// servermode
+		bind := "127.0.0.1:" + strconv.Itoa(*port)
+		log.Println("Starting webserver on", bind+"/"+*prefix)
+		run_server(bind, *prefix)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -44,10 +44,9 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func main() {
-	appPrefix := "metadeck"
+func run_server(bind string, appPrefix string) {
 	http.HandleFunc(fmt.Sprintf("/%s/", appPrefix), handle)
 	staticPath := fmt.Sprintf("/%s/static/", appPrefix)
 	http.Handle(staticPath, http.StripPrefix(staticPath, http.FileServer(http.Dir("static"))))
-	http.ListenAndServe(":8981", nil)
+	http.ListenAndServe(bind, nil)
 }


### PR DESCRIPTION
Adds a batch mode to aggregate decks directly from the command line, which allows better integration with other tools. Also adds command-line flags to enable this batch functionality and set input and output directories. If no mode is specified on the command-line, it defaults to webserver mode so as not to break existing functionality.

Run the binary with the `-help` flag to get the following usage information:

```
Usage of ./mtg-aggregatedeck:
  -batch
        Whether to run in batch mode (requires -decks and -out)
  -decks string
        (batch mode) A directory with subdirectories containing deck files
  -out string
        (batch mode) Output directory for aggregated decks; will be created if it doesn't exist
  -port int
        (web mode) Port to bind to (default 8981)
  -prefix string
        (web mode) Route at which to serve the web interface (default "metadeck")
  -v    Give more verbose output
  -web
        Whether to run in webserver mode
```